### PR TITLE
Add Docker Configuration for Order Service with PostgreSQL Integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:22
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 # ms_order
 
-This project is a Spring Boot application for managing order services within a microservices architecture.
+The Order Service is a core component of a microservice architecture responsible for handling 
+product orders. It manages the creation, tracking, and updating of customer orders. Once an order 
+is placed, this service communicates with the [Delivery Service](https://github.com/SvetlanaVys/ms_delivery) to coordinate the shipment of products.
 
+### Technologies
+* **Java 20** and **Spring Boot 3** for building RESTful APIs.
+* **PostgreSQL** Database for data storage (RDB).
+* **Kafka** ensuring reliable and asynchronous communication.
+* **OpenAPI** specification for well-defined and documented API interactions.
+* **Docker** for containerization.
+* **Maven** for project management and dependency resolution.
 
-### Running the Application
+### Microservice Communication
+This service sends order details to the [Delivery Service](https://github.com/SvetlanaVys/ms_delivery) via messaging protocol using Kafka after an order is placed.
+The service requests delivery information from the Delivery Service through HTTP, utilizing the OpenAPI.
 
-To run the application in IntelliJ IDEA with the local profile:
+### How to Run the Application
 
-1. **Open the project** in IntelliJ IDEA.
-2. **Select the Run Configuration:**
-   - Go to Run > Edit Configurations.
-   - Under `VM Options`, add the following:
-      ```bash
-      -Dspring.profiles.active=local
+1. **Maven**:
+   ```bash
+   mvn clean install
 
-3. **Start the application**
+2. **Build the Docker Image**:
+   Run the following command to build the Docker image:
+   ```bash
+   docker build -t ms-order-api .
+
+2. **Start the Application**:
+   Run the following command to bring up the application along with all its services:
+   ```bash
+    docker-compose up --build
+
+3. **Access Swagger**:
+   Once the application is up, you can access the Swagger UI at: <br />
+   http://localhost:8080/ms-order/swagger-ui/index.html

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ product orders. It manages the creation, tracking, and updating of customer orde
 is placed, this service communicates with the [Delivery Service](https://github.com/SvetlanaVys/ms_delivery) to coordinate the shipment of products.
 
 ### Technologies
-* **Java 20** and **Spring Boot 3** for building RESTful APIs.
+* **Java 22** and **Spring Boot 3** for building RESTful APIs.
 * **PostgreSQL** Database for data storage (RDB).
 * **Kafka** ensuring reliable and asynchronous communication.
 * **OpenAPI** specification for well-defined and documented API interactions.
@@ -16,22 +16,44 @@ is placed, this service communicates with the [Delivery Service](https://github.
 This service sends order details to the [Delivery Service](https://github.com/SvetlanaVys/ms_delivery) via messaging protocol using Kafka after an order is placed.
 The service requests delivery information from the Delivery Service through HTTP, utilizing the OpenAPI.
 
-### How to Run the Application
+## How to Run the Application
+
+### Running the Application Locally
+
+To run the application in IntelliJ IDEA with the local profile:
+
+1. **Open the project** in IntelliJ IDEA.
+2. **Maven**:
+   ```bash
+   mvn clean install
+3. **Select the Run Configuration:**
+   - Go to Run > Edit Configurations.
+   - Under `VM Options`, add the following:
+     ```bash
+     -Dspring.profiles.active=local
+
+4. **Start the application**
+
+### Running the Application with Docker
 
 1. **Maven**:
    ```bash
    mvn clean install
 
-2. **Build the Docker Image**:
+2. **Create shared network** if you haven't already created it in delivery service
+   ```bash
+   docker network create marketplace-network
+
+3. **Build the Docker Image**:
    Run the following command to build the Docker image:
    ```bash
    docker build -t ms-order-api .
 
-2. **Start the Application**:
+4. **Start the Application**:
    Run the following command to bring up the application along with all its services:
    ```bash
     docker-compose up --build
 
-3. **Access Swagger**:
+#### Access Swagger:
    Once the application is up, you can access the Swagger UI at: <br />
    http://localhost:8080/ms-order/swagger-ui/index.html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,25 @@
+# file: docker-compose.yaml
+version: "3.9"
+services:
+  postgres:
+    image: postgres:13.3
+    environment:
+      POSTGRES_DB: ms-order
+      POSTGRES_USER: svadmin
+      POSTGRES_PASSWORD: Qwerty123
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d postgres -U svadmin" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+  ms-order-api:
+    build: .
+    image: ms-order-api
+    ports:
+      - 8080:8080
+    links:
+      - postgres
+    depends_on:
+      - postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,25 +1,41 @@
 # file: docker-compose.yaml
 version: "3.9"
 services:
-  postgres:
-    image: postgres:13.3
+  postgres-order:
+    image: postgres:16
     environment:
       POSTGRES_DB: ms-order
       POSTGRES_USER: svadmin
       POSTGRES_PASSWORD: Qwerty123
     ports:
       - 5432:5432
+    volumes:
+      - postgres-order-data:/var/lib/postgresql/data # Persist data in a named volume
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -d postgres -U svadmin" ]
       interval: 10s
       timeout: 10s
       retries: 5
+    networks:
+      - marketplace-network
   ms-order-api:
     build: .
     image: ms-order-api
+    environment:
+      DELIVERY_URL: http://ms-delivery-api:8081/ms-delivery
+      POSTGRES_URL: jdbc:postgresql://postgres-order:5432/ms-order
+      POSTGRES_USER: svadmin
+      POSTGRES_PASSWORD: Qwerty123
     ports:
       - 8080:8080
-    links:
-      - postgres
     depends_on:
-      - postgres
+      - postgres-order
+    networks:
+      - marketplace-network
+
+volumes:
+  postgres-order-data: # Named volume for PostgreSQL data
+
+networks:
+  marketplace-network:
+    external: true

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.svysk</groupId>
 	<artifactId>ms_order</artifactId>
-	<version>0.0.1</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<name>ms_order</name>
 	<description>Order service</description>
 	<url/>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
 			<version>2.1.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 		</dependency>
@@ -144,6 +149,13 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.10</version>
+				<configuration>
+					<useFile>false</useFile>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,9 +10,9 @@ spring:
     enabled: true
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://postgres:5432/ms-order
-    username: svadmin
-    password: Qwerty123
+    url: ${POSTGRES_URL}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,18 +6,24 @@ server:
 spring:
   application:
     name: ms_order
-  h2:
-    console:
-      enabled: true
+  liquibase:
+    enabled: true
   datasource:
-    url: jdbc:h2:mem:testdb-order
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: password
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://postgres:5432/ms-order
+    username: svadmin
+    password: Qwerty123
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-
+    database: postgresql
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true
+    hibernate:
+      ddl-auto: update
 # Reference the environment variable
 delivery:
   url: ${DELIVERY_URL}
-


### PR DESCRIPTION
This PR introduces Docker configurations to containerize the Order Service and integrate it with a PostgreSQL database. The Docker setup includes a `Dockerfile`  and a `docker-compose.yaml`.

### Changes Made
- **Dockerfile for Order Service:**

  - Created a `Dockerfile` to build and run the Order Service in a Docker container.
  - Configured the `Dockerfile` with necessary image
 

- **Docker Compose Configuration:**

  - Added a `docker-compose.yaml` file to define services for the Order Service and PostgreSQL.
  - Configured the PostgreSQL service to initialize with a default database, user, and password.
  - Linked the Order Service to PostgreSQL through environment variables, making it easier to connect and manage database credentials.

### Usage

- **Build and Start the Containers**: Build and run the Order Service and PostgreSQL containers:

  ```bash 
  docker build -t ms-order-api .
  docker-compose up

- **Access the Application**:

   - The Order Service should now be accessible on: [http://localhost:8080/ms-order/swagger-ui/index.html](http://localhost:8080/ms-order/swagger-ui/index.html)
   - PostgreSQL can be accessed internally by the Order Service as postgres on port 5432

### Verification

- **Confirm Service Availability:**

  - Ensure that both the Order Service and PostgreSQL containers are running without errors:
    ```bash 
    docker ps

  - Inspect logs to verify that the Order Service has successfully connected to PostgreSQL:
    ```bash 
    docker-compose logs ms-order-api
